### PR TITLE
Make gde pip installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+# Copyright 2018 IBM. All Rights Reserved.
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from setuptools import find_packages, setup
+
+with open('README.md') as f:
+    long_description = f.read()
+
+setup(
+    name='graph_def_editor',
+    version='0.1.0',
+    description=('TensorFlow Graph Def Editor'),
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    packages=find_packages(),
+    install_requires=['numpy<=1.14.5', 'tensorflow'],
+    include_package_data=True,
+    zip_safe=False,
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Education',
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering :: Mathematics',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Software Development :: Libraries',
+    ],
+    license='Apache License, Version 2.0',
+    maintainer='Graph Def Developers',
+    maintainer_email='',
+)


### PR DESCRIPTION
Created setup.py to build distribution. 

Use command `python setup.py sdist bdist_wheel` to generate a python wheel in `dist/graph_def_editor*.whl`.

This can then be installed with `pip install dist/graph_def_editor*.whl`.

Fixes #3